### PR TITLE
Update existTfstate.sh

### DIFF
--- a/_scr/existTfstate.sh
+++ b/_scr/existTfstate.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rootpath=$(dirname $(cd $(dirname $0); pwd))
-find ${rootpath}/props/ctr_* -type f -name terraform.tfstate|xargs -n 1 -i dirname {}
+find ${rootpath}/props/ctr_* -type f -name '*.json' -exec grep -H 'propertyVersion' {} +


### PR DESCRIPTION
xargsで2000以上のPropertyがある場合に受け渡せないため、コマンドを変更する必要がある。